### PR TITLE
Improve GL state safety code

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -3374,7 +3374,12 @@ StudioRenderModel
 */
 void CStudioModelRenderer::StudioRenderModel()
 {
-	if (m_pCurrentEntity->curstate.renderfx == kRenderFxGlowShell)
+
+	// Save texture states before rendering, so we don't
+	// cause any bugs in HL by changing texture binds, etc
+	R_SaveGLStates();
+
+	if ( m_pCurrentEntity->curstate.renderfx == kRenderFxGlowShell )
 	{
 		m_pCurrentEntity->curstate.renderfx = kRenderFxNone;
 		StudioRenderFinal();
@@ -3392,6 +3397,9 @@ void CStudioModelRenderer::StudioRenderModel()
 	{
 		StudioRenderFinal();
 	}
+
+	// Restore saved states
+	R_RestoreGLStates();
 }
 
 /*
@@ -5038,6 +5046,10 @@ StudioRenderModelEXT
 */
 void CStudioModelRenderer::StudioRenderModelEXT()
 {
+	// Save texture states before rendering, so we don't
+	// cause any bugs in HL by changing texture binds, etc
+	R_SaveGLStates();
+
 	// I don't give a shit, make sure
 	glPushMatrix();
 	glMatrixMode(GL_MODELVIEW);
@@ -5072,6 +5084,9 @@ void CStudioModelRenderer::StudioRenderModelEXT()
 
 	if (m_pCvarModelsBBoxDebug->value > 0)
 		StudioDrawBBox();
+
+	// Restore saved states
+	R_RestoreGLStates();
 }
 
 /*

--- a/cl_dll/bsprenderer.h
+++ b/cl_dll/bsprenderer.h
@@ -93,8 +93,6 @@ public:
 	void RestoreWorldDrawing( );
 
 	void CreateTextures( );
-	void SaveMultiTexture( );
-	void RestoreMultiTexture( );
 
 	void FreeBuffer( );
 	void GenerateVertexArray( );
@@ -358,24 +356,6 @@ public:
 
 	Vector				m_vDecalMins;
 	Vector				m_vDecalMaxs;
-
-private:
-	GLint				m_iBlendActive;
-	GLint				m_iTU1bind;
-	GLint				m_iTU2bind;
-	GLint				m_iTU3bind;
-	GLint				m_iTU4bind;
-	GLint				m_iTU1tex2dEnable;
-	GLint				m_iTU2tex2dEnable;
-	GLint				m_iTU3tex2dEnable;
-	GLint				m_iTU4tex2dEnable;
-	GLint				m_iActiveTU;
-	GLint				m_iCLActiveTU;
-	GLint				m_iTU1BlendMode;
-
-	GLint				m_iAlphaFunc;
-	GLclampf			m_AlphaVal;
-	GLint				m_iAlphaTestEnabled;
 
 };
 extern CBSPRenderer gBSPRenderer;

--- a/cl_dll/mirrormanager.cpp
+++ b/cl_dll/mirrormanager.cpp
@@ -272,7 +272,8 @@ void CMirrorManager::DrawMirrorPass( )
 	// Draw world
 	gBSPRenderer.DrawNormalTriangles();
 
-	gBSPRenderer.SaveMultiTexture();
+	R_SaveGLStates();
+	RenderFog();
 
 	for(int i = 0; i < gBSPRenderer.m_iNumRenderEntities; i++)
 	{
@@ -300,7 +301,7 @@ void CMirrorManager::DrawMirrorPass( )
 	// Draw particles
 	gParticleEngine.DrawParticles();
 
-	gBSPRenderer.RestoreMultiTexture();
+	R_RestoreGLStates();
 }
 
 /*

--- a/cl_dll/rendererdefs.h
+++ b/cl_dll/rendererdefs.h
@@ -709,6 +709,27 @@ struct cabledata_t
 	short leafnums[MAX_ENT_LEAFS];
 };
 
+struct glstate_t
+{
+	glstate_t() :
+		blending_enabled(false),
+		alphatest_enabled(false),
+		alphatest_func(0),
+		alphatest_value(0),
+		active_texunit(0),
+		active_clienttexunit(0)
+	{}
+
+	bool blending_enabled;
+
+	bool alphatest_enabled;
+	GLint alphatest_func;
+	GLfloat alphatest_value;
+
+	GLint active_texunit;
+	GLint active_clienttexunit;
+};
+
 //========================================
 //				GLOBAL FUNCTION CALLS
 //
@@ -768,6 +789,13 @@ extern void		FixVectorForSpotlight( Vector &vec );
 extern void		SV_FindTouchedLeafs( entextradata_t *ent, mnode_t *node );
 
 extern byte		*ResizeArray( byte *pOriginal, int iSize, int iCount );
+
+extern void		R_SaveGLStates(void);
+extern void		R_RestoreGLStates(void);
+
+extern void		R_Init(void);
+extern void		R_VidInit(void);
+extern void		R_Shutdown(void);
 
 extern Vector	g_vecFull;
 //extern Vector	g_vecZero;

--- a/cl_dll/watershader.cpp
+++ b/cl_dll/watershader.cpp
@@ -929,7 +929,7 @@ void CWaterShader::DrawScene( ref_params_t *pparams, bool isrefracting )
 	// Draw world
 	gBSPRenderer.DrawNormalTriangles();
 
-	gBSPRenderer.SaveMultiTexture();
+	R_SaveGLStates();
 
 	if((m_pCvarWaterShader->value > 1) || isrefracting)
 	{
@@ -989,7 +989,7 @@ void CWaterShader::DrawScene( ref_params_t *pparams, bool isrefracting )
 		}
 	}
 
-	gBSPRenderer.RestoreMultiTexture();
+	R_RestoreGLStates();
 	m_iNumPasses++;
 }
 


### PR DESCRIPTION
Tracking of OpenGL texture states has been improved to avoid having it interfere with GoldSrc's internal texture states by @TheOverfloater

Original Commit: https://github.com/TheOverfloater/trinity-engine/commit/310ae85aab5ce256c8a0402ac6279e2f8d59ff2a

Co-Authored-By: TheOverfloater <66183502+TheOverfloater@users.noreply.github.com>